### PR TITLE
Fix `alpha-values` false positives for `<number>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Head
+
+### Fixed
+
+- `alpha-values` false positives for `<number>`
+
 ## 3.1.0
 
 ### Added

--- a/lib/rules/alpha-values/__tests__/index.js
+++ b/lib/rules/alpha-values/__tests__/index.js
@@ -13,8 +13,16 @@ testRule({
       description: "Value on scale",
     },
     {
+      code: "a { opacity: 0.5; }",
+      description: "Number value",
+    },
+    {
       code: "a { color: hsl(0deg 0% 0% / 10%) }",
       description: "Value on scale in function",
+    },
+    {
+      code: "a { color: hsl(0deg 0% 0% / 0.5) }",
+      description: "Number value in function",
     },
     {
       code: "a { color: hsl(0deg 0% 0%) }",

--- a/lib/rules/alpha-values/index.js
+++ b/lib/rules/alpha-values/index.js
@@ -53,7 +53,9 @@ const rule = (primary, secondary, { fix }) => {
       }
 
       function check(node) {
-        const { value } = node;
+        const { value, unit } = node;
+
+        if (unit !== "%") return;
 
         if (isOnNumericScale(primary, value)) return;
 


### PR DESCRIPTION
<!-- Please associate each pull request with an open issue unless it's a documentation fix. -->

> Which issue, if any, is this issue related to?

Closes #92

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
